### PR TITLE
chore: Fix npx typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Scaffold out an [Express app](https://www.npmjs.com/package/express).
 
 ```
 $ npm init express-app
-$ npmx create-express-app
+$ npx create-express-app
 ```
 
 With `npm@6` this will run this package with `npx`.  If you are on an earlier version of `npm` you will


### PR DESCRIPTION
Not sure if `npmx` is some new global hotness I'm not aware of but I think this is at typo :)

```
master ?:4 ᎒ npmx create-express-app
zsh: command not found: npmx
[~/workspace/foo]
master ?:4 ᎒ npx create-express-app
? App name: (foo)
```